### PR TITLE
Add AUTH_URI config example

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,4 +1,5 @@
 const authClient = new PingOneAuthClient({
+  AUTH_URI: "https://auth.pingone.com", // see Ping console - could be https://auth.pingone.eu
   environmentId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
   clientId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
   redirectUri: 'http://localhost:8080',


### PR DESCRIPTION
By default, the AUTH_URI is set to https://auth.pingone.com. 
Customers who are on https://auth.pingone.eu will get a mysterious "Not Found" error if they don't set the `AUTH_URI` to 'https://auth.pingone.eu'