### PR TITLE
Add AUTH_URI config example

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,4 +1,5 @@
 const authClient = new PingOneAuthClient({
+  AUTH_URI: "https://auth.pingone.com", // see Ping console - could be https://auth.pingone.eu
   environmentId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
   clientId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
   redirectUri: 'http://localhost:8080',

--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,5 @@
 const authClient = new PingOneAuthClient({
-  AUTH_URI: "https://auth.pingone.com", // see Ping console - could be https://auth.pingone.eu
+  AUTH_URI: 'https://auth.pingone.com', // 'https://auth.pingone.eu', 'https://auth.pingone.ca' or 'https://auth.pingone.asia'
   environmentId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
   clientId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
   redirectUri: 'http://localhost:8080',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oidc-implicit-sample",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oidc-implicit-sample",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@ping-identity/p14c-js-sdk-auth": "^1.0.0-pre.2",
         "http-server": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-implicit-sample",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "Simple Javascript client that implements the OpenID Connect implicit flow",
   "keywords": [


### PR DESCRIPTION
Created from #16 (which was raised Apr 24, 2021) to facilitate fast merge

By default, the AUTH_URI is set to https://auth.pingone.com/.
Customers who are on https://auth.pingone.eu/ will get a mysterious "Not Found" error if they don't set the `AUTH_URI` to 'https://auth.pingone.eu/'